### PR TITLE
Don't require the application to create rows.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ Then you can use it like so:
 
 ``` ruby
 shop = Shop.find(1)
-shop.increment_version!
-shop.increment_version!
+shop.new_version!
+shop.new_version!
 shop.version #=> 2
 ```
 

--- a/lib/generators/templates/multirow_counter_migration.rb
+++ b/lib/generators/templates/multirow_counter_migration.rb
@@ -8,7 +8,7 @@ class Add<%= counter_name.classify %>CounterTo<%= model_name.classify %> < Activ
       t.integer :value
     end
 
-    add_index :<%= [model_name, counter_name].join('_').tableize %>, :<%= model_name %>_id
+    add_index :<%= [model_name, counter_name].join('_').tableize %>, [:<%= model_name %>_id, :counter_id], :unique => true
 
     # You may want to consider moving this into a background task if it takes too long
     <%= model_name.classify %>.find_each do |<%= model_name %>|

--- a/lib/multirow_counter/extension.rb
+++ b/lib/multirow_counter/extension.rb
@@ -17,7 +17,7 @@ module MultirowCounter
       define_method("multirow_counter_#{counter_name}", &getter)
 
       # define increment method
-      define_method("increment_#{counter_name}") do |incr = 1|
+      define_method("new_#{counter_name}!") do |incr = 1|
         counter_relation = const.where(class_name.foreign_key => id)
         randomly_selected_counter_row = rand(num_rows) + 1
 


### PR DESCRIPTION
This gem currently requires us to create a bunch of rows for each shop whose version we're tracking. It seems easier to just create those rows if they're accessed and found to be missing.

Will link to related pull request in shopify shortly.

Review: @hornairs @camilo @jstorimer @boourns 
